### PR TITLE
Updated version of cryptography

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pika==1.0.1
 aiohttp==3.3.2
 sphinx_rtd_theme
-cryptography==2.3.1
+cryptography==2.6.1
 pgpy
 psycopg2-binary==2.7.5
 PyYaml


### PR DESCRIPTION

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
pgpy depends on a newer version of cryptography then the one we pinned. Updating to a newer version fixes the pip installation of libraries. So now the tox tests pass (on my computer at least).


### Related issues:
Fixes #11