### PR TITLE
Removed config assertion to enable config-file less config

### DIFF
--- a/lega/utils/amqp.py
+++ b/lega/utils/amqp.py
@@ -19,8 +19,6 @@ def get_connection(domain, blocking=True):
     heartbeat values are read from the CONF argument.
     So are the SSL options.
     """
-    assert domain in CONF.sections(), "Section not found in config file"
-
     LOG.info(f'Getting a connection to {domain}')
     params = CONF.get_value(domain, 'connection', raw=True)
     LOG.debug(f"Initializing a connection to: {params}")


### PR DESCRIPTION



### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
The config lookup works by first checking for the <SECTION>_<VAR> env var and then looking for the specified <var> in the [<section>] of the config file. Checking for a specific section in the configuration the will only work if there is a configuration file, since sections are not a defined concept in the environment. The test is also unnecesary since the following var lookup will fail anyway if it's not present.


### Changes made:
Removed one assertion that checked for a certain section in the configuration file.

### Related issues:
#8 