### PR TITLE
Bugfix coveralls pin version and new LocalEGA-deploy-init S3 Archive keys

### DIFF
--- a/deploy/bootstrap/settings.rc
+++ b/deploy/bootstrap/settings.rc
@@ -10,8 +10,8 @@ DOCKER_PORT_s3=9000
 DB_LEGA_IN_PASSWORD=$(get_trace_value secrets.pg_in_password)
 DB_LEGA_OUT_PASSWORD=$(get_trace_value secrets.pg_out_password)
 
-S3_ACCESS_KEY=$(get_trace_value secrets.s3_access_key)
-S3_SECRET_KEY=$(get_trace_value secrets.s3_secret_key)
+S3_ACCESS_KEY=$(get_trace_value secrets.s3_archive_access_key)
+S3_SECRET_KEY=$(get_trace_value secrets.s3_archive_secret_key)
 
 if [[ "${force}" != "force" ]] && [[ "${DEPLOY_DEV}" = "yes" ]]; then
     S3_ACCESS_KEY=dummyaccesskey

--- a/lega/conf/__init__.py
+++ b/lega/conf/__init__.py
@@ -111,7 +111,7 @@ class Configuration(configparser.ConfigParser):
             print('Error with --log:', repr(e), file=sys.stderr)
 
     def setup(self, args=None, encoding='utf-8'):
-        """Setup, that is all."""
+        """Run setup, that is all."""
         self._load_conf(args, encoding)
         self._load_log_conf(args)
 

--- a/tests/unit/coveralls.py
+++ b/tests/unit/coveralls.py
@@ -8,7 +8,7 @@ import sys
 # Solution provided by https://stackoverflow.com/questions/32757765/conditional-commands-in-tox-tox-travis-ci-and-coveralls
 
 if __name__ == '__main__':
-    if 'TRAVIS' in os.environ:
+    if 'COVERALLS_REPO_TOKEN' in os.environ:
         rc = call('coveralls')
         sys.stdout.write("Coveralls report from CI.\n")
         # raise SystemExit(rc)

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ max-line-length = 160
 max-complexity = 10
 
 [testenv:flake8]
-deps = pydocstyle==3.0.0
+deps = pydocstyle
        flake8
        flake8-docstrings
 commands = flake8 .

--- a/tox.ini
+++ b/tox.ini
@@ -20,12 +20,13 @@ commands = flake8 .
 
 [testenv:unit_tests]
 passenv = COVERALLS_REPO_TOKEN
-deps = coverage
+deps = 
+       coverage==4.5.4
        -rrequirements.txt
        -rtests/unit/requirements.txt
 commands = coverage run -m pytest -x tests/unit
 	       coverage report
-           coveralls
+           python tests/unit/coveralls.py
 
 [gh-actions]
 python =


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Pull request long description:
<!-- Describe your pull request in detail. -->

Fix failing coveralls dependency because of coverage 5.0.0

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1. pinned coverage to 4.5.0 till coveralls 5.0+ update is done here: https://github.com/coveralls-clients/coveralls-python/issues/203
2. removed old pydocstyle pinned dependency
3. fix flake8 miss in conf init
4. update with new S3 Archive keys in bootstrap

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num>" to notify Github that this PR fixes an issue. -->

Closes #22 