### PR TITLE
Use checksums as identifier of a file throughout steps

### DIFF
--- a/.github/workflows/int.yml
+++ b/.github/workflows/int.yml
@@ -37,7 +37,7 @@ jobs:
         pip install git+https://github.com/EGA-archive/crypt4gh.git@v1.1
         pip install pika==1.0.1
         pip install shyaml
-        sudo apt-get install expect
+        sudo apt-get install expect postgresql-client
     - name: Build image
       run:  |
         docker build -f Dockerfile \

--- a/deploy/bootstrap/run.sh
+++ b/deploy/bootstrap/run.sh
@@ -297,6 +297,8 @@ services:
     labels:
         lega_label: "localega-db"
     image: neicnordic/sda-db:latest
+    ports:
+      - "5432:5432"
     volumes:
       - db:/var/lib/postgresql
       - ./config/certs/db.ca.crt:/tls/db.ca.crt

--- a/lega/finalize.py
+++ b/lega/finalize.py
@@ -29,7 +29,7 @@ def work(data):
     user = data['user']
     encrypted_checksum = data['file_checksum']
     stable_id = data['stable_id']
-    LOG.info("Mapping file_id %s to stable_id %s", filepath, stable_id)
+    LOG.info("Mapping file with path %s and checksum %s to stable_id %s", filepath, encrypted_checksum, stable_id)
 
     # Remove file from the inbox
     # TODO

--- a/lega/finalize.py
+++ b/lega/finalize.py
@@ -25,16 +25,18 @@ LOG = logging.getLogger(__name__)
 @errors.catch(ret_on_error=(None, True))
 def work(data):
     """Read a message containing the ids and add it to the database."""
-    file_id = data['file_id']
+    filepath = data['filepath']
+    user = data['user']
+    encrypted_checksum = data['file_checksum']
     stable_id = data['stable_id']
-    LOG.info("Mapping file_id %s to stable_id %s", file_id, stable_id)
+    LOG.info("Mapping file_id %s to stable_id %s", filepath, stable_id)
 
     # Remove file from the inbox
     # TODO
 
-    db.set_stable_id(file_id, stable_id)  # That will flag the entry as 'Ready'
+    db.set_stable_id(filepath, user, encrypted_checksum, stable_id)  # That will flag the entry as 'Ready'
 
-    LOG.info("Stable ID %s mapped to %s", stable_id, file_id)
+    LOG.info("Stable ID %s mapped to %s", stable_id, filepath)
     return (None, False)
 
 

--- a/lega/ingest.py
+++ b/lega/ingest.py
@@ -58,8 +58,7 @@ def work(fs, inbox_fs, data):
     org_msg = data.copy()
     data['org_msg'] = org_msg
 
-    # this uses a function to set the filepath and user_id
-    # in order to set the encrypted key we will do an update based on them
+    # Insert in database
     file_id = db.insert_file(filepath, user_id)
 
     data['file_id'] = file_id  # must be there: database error uses it
@@ -85,6 +84,7 @@ def work(fs, inbox_fs, data):
 
     sha = hashlib.sha256()
     # Strip the header out and copy the rest of the file to the archive
+    # if the checksum was not provided calculate it
     LOG.debug('Opening %s', filepath)
     with inbox.open(filepath, 'rb') as infile:
         LOG.debug('Reading header | file_id: %s', file_id)
@@ -99,6 +99,7 @@ def work(fs, inbox_fs, data):
         # return to start of file
         infile.seek(0)
 
+        # now start splitting the header from the rest of the file
         header_bytes = get_header(infile)
         header_hex = header_bytes.hex()
         data['header'] = header_hex
@@ -126,7 +127,7 @@ def work(fs, inbox_fs, data):
 
     # Keep it in the messages to indentify the file
     data['file_checksum'] = encrypted_checksum
-    # Insert in database
+    # Insert checksum in database
     db.set_file_encrypted_checksum(file_id, encrypted_checksum, encrypted_checksum_type)
 
     LOG.debug("Reply message: %s", data)

--- a/lega/utils/db.py
+++ b/lega/utils/db.py
@@ -142,6 +142,18 @@ def insert_file(filename, user_id):
         raise Exception('Database issue with insert_file')
 
 
+def set_file_encrypted_checksum(file_id, encrypted_checksum, encrypted_checksum_type):
+    """Insert encrypted checksum."""
+    with connection.cursor() as cur:
+        cur.execute('UPDATE local_ega.files '
+                    'SET inbox_file_checksum = %(encrypted_checksum)s, '
+                    '    inbox_file_checksum_type = %(encrypted_checksum_type)s'
+                    'WHERE id = %(file_id)s;',
+                    {'encrypted_checksum': encrypted_checksum,
+                     'encrypted_checksum_type': encrypted_checksum_type.upper(),
+                     'file_id': file_id})
+
+
 def set_error(file_id, error, from_user=False):
     """Store error related to ``file_id`` in database."""
     assert file_id, 'Eh? No file_id?'
@@ -176,18 +188,19 @@ def mark_in_progress(file_id):
                      'file_id': file_id})
 
 
-def set_stable_id(file_id, stable_id):
-    """Update File ``file_id`` stable ID."""
-    assert file_id, 'Eh? No file_id?'
-    LOG.debug('Updating file_id %s with stable ID "%s"', file_id, stable_id)
+def set_stable_id(filepath, user, encrypted_checksum, stable_id):
+    """Update File with stable ID."""
+    LOG.debug('Updating filepath %s for user %s with stable ID "%s"', filepath, user, stable_id)
     with connection.cursor() as cur:
         cur.execute('UPDATE local_ega.files '
                     'SET status = %(status)s, '
                     '    stable_id = %(stable_id)s '
-                    'WHERE id = %(file_id)s;',
+                    'WHERE elixir_id = %(user)s AND inbox_path = %(filepath)s AND inbox_file_checksum = %(encrypted_checksum)s;',
                     {'status': 'READY',
-                     'file_id': file_id,
-                     'stable_id': stable_id})
+                     'user': user,
+                     'stable_id': stable_id,
+                     'filepath': filepath,
+                     'encrypted_checksum': encrypted_checksum})
 
 
 def store_header(file_id, header):

--- a/lega/utils/db.py
+++ b/lega/utils/db.py
@@ -195,12 +195,17 @@ def set_stable_id(filepath, user, encrypted_checksum, stable_id):
         cur.execute('UPDATE local_ega.files '
                     'SET status = %(status)s, '
                     '    stable_id = %(stable_id)s '
-                    'WHERE elixir_id = %(user)s AND inbox_path = %(filepath)s AND inbox_file_checksum = %(encrypted_checksum)s;',
+                    'WHERE elixir_id = %(user)s AND inbox_path = %(filepath)s '
+                    ' AND inbox_file_checksum = %(encrypted_checksum)s'
+                    ' AND status != %(disabled)s;',
                     {'status': 'READY',
                      'user': user,
                      'stable_id': stable_id,
                      'filepath': filepath,
-                     'encrypted_checksum': encrypted_checksum})
+                     'encrypted_checksum': encrypted_checksum,
+                     # The completed status is to avoid DISABLED file
+                     # ingested twice with same checksum and file id and path
+                     'disabled': 'DISABLED'})
 
 
 def store_header(file_id, header):

--- a/lega/verify.py
+++ b/lega/verify.py
@@ -154,7 +154,7 @@ def work(key, mover, data):
     org_msg.pop('file_id', None)
     org_msg['decrypted_checksums'] = [{'type': 'sha256', 'value': digest_sha256},
                                       {'type': 'md5', 'value': digest_md5}]  # for stable id
-    # org_msg['reference'] = file_id
+    org_msg['file_checksum'] = data['file_checksum']
     LOG.debug(f"Reply message: {org_msg}")
     return (org_msg, False)
 

--- a/tests/integration/ingestion.bats
+++ b/tests/integration/ingestion.bats
@@ -92,6 +92,11 @@ function teardown() {
     [[ "$output" =~ "reason: Session key (likely) already used." ]]
 }
 
+@test "Get an accession id" {
+    
+    lega_stable_id $(uuidgen) 10 v1.stableIDs
+}
+
 # Ingesting a file not in Crypt4GH format
 # ---------------------------------------
 #

--- a/tests/unit/test_finalize.py
+++ b/tests/unit/test_finalize.py
@@ -21,9 +21,9 @@ class testFinalize(unittest.TestCase):
     def test_work(self, mock_db):
         """Test finalize worker, should insert into database."""
         # mock_db.set_stable_id.return_value = mock.Mock()
-        data = {'stable_id': '1', 'file_id': '123'}
+        data = {'stable_id': '1', 'filepath': '/123.c4gh', 'user': 'user', 'file_checksum': 'some256'}
         work(data)
-        mock_db.set_stable_id.assert_called_with('123', '1')
+        mock_db.set_stable_id.assert_called_with('/123.c4gh', 'user', 'some256', '1')
 
     @mock.patch('lega.finalize.consume')
     def test_main(self, mock_consume):

--- a/tests/unit/test_ingest.py
+++ b/tests/unit/test_ingest.py
@@ -34,13 +34,17 @@ class testIngest(unittest.TestCase):
         mock_broker = mock.MagicMock(name='channel')
         mock_broker.channel.return_value = mock.Mock()
         infile = filedir.write('infile.in', bytearray.fromhex(c4gh_data.ENC_FILE))
-        data = {'filepath': infile, 'user': 'user_id@elixir-europe.org'}
+        data = {'filepath': infile, 'user': 'user_id@elixir-europe.org',
+                "encrypted_checksums": [{"type": "sha256", "value": "efa8ce457b27728b7af3351ed77793a6421190877128451830d68babbacf3021"}]}
         result = work(store, mock_broker, data)
         mocked = ({'filepath': infile, 'user': 'user_id@elixir-europe.org',
                    'file_id': 32,
-                   'org_msg': {'filepath': infile, 'user': 'user_id@elixir-europe.org'},
+                   'file_checksum': "efa8ce457b27728b7af3351ed77793a6421190877128451830d68babbacf3021",
+                   'org_msg': {'filepath': infile, 'user': 'user_id@elixir-europe.org',
+                               "encrypted_checksums": [{"type": "sha256", "value": "efa8ce457b27728b7af3351ed77793a6421190877128451830d68babbacf3021"}]},
                    'header': '686561646572',
                    'archive_path': 'smth'}, False)
+        print(result)
         self.assertEqual(mocked, result)
         filedir.cleanup()
 

--- a/tests/unit/test_ingest.py
+++ b/tests/unit/test_ingest.py
@@ -44,7 +44,31 @@ class testIngest(unittest.TestCase):
                                "encrypted_checksums": [{"type": "sha256", "value": "efa8ce457b27728b7af3351ed77793a6421190877128451830d68babbacf3021"}]},
                    'header': '686561646572',
                    'archive_path': 'smth'}, False)
-        print(result)
+        self.assertEqual(mocked, result)
+        filedir.cleanup()
+
+    @tempdir()
+    @mock.patch('lega.ingest.get_header')
+    @mock.patch('lega.ingest.db')
+    def test_work_2(self, mock_db, mock_header, filedir):
+        """Test ingest worker, should send a messge for generated checksum."""
+        # Mocking a lot of stuff, as it is previously tested
+        mock_header.return_value = b'header'
+        mock_db.insert_file.return_value = 32
+        store = mock.MagicMock()
+        store.location.return_value = 'smth'
+        store.open.return_value = mock.MagicMock()
+        mock_broker = mock.MagicMock(name='channel')
+        mock_broker.channel.return_value = mock.Mock()
+        infile = filedir.write('infile.in', bytearray.fromhex(c4gh_data.ENC_FILE))
+        data = {'filepath': infile, 'user': 'user_id@elixir-europe.org'}
+        result = work(store, mock_broker, data)
+        mocked = ({'filepath': infile, 'user': 'user_id@elixir-europe.org',
+                   'file_id': 32,
+                   'file_checksum': "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                   'org_msg': {'filepath': infile, 'user': 'user_id@elixir-europe.org'},
+                   'header': '686561646572',
+                   'archive_path': 'smth'}, False)
         self.assertEqual(mocked, result)
         filedir.cleanup()
 


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change

### Pull request long description:
<!-- Describe your pull request in detail. -->
Checksums used to identify files in the finalize step.
Currently we use a method that is not sustainable long term, and we need to change that to checksums. 
We will use encrypted checksums sent by the inbox.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1. calculate checksum for encrypted file if not provided in the message
2. add `file_checksum` to identify the message in `finalize`
3. add `file_checksum` in `ingest` to pass along the just file checksum
4. fix tests
5. store `encrypted_checksum` in the db under `inbox_file_checksum` along with type which we preselect as `sha256`
6. identify a file in the db in the finalize step by `filepath`, `file_checksum` and `user_id`

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num>" to notify Github that this PR fixes an issue. -->
Many.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

the official docs say message structure is:
```
{
   "user":"john",
   "filepath":"somedir/encrypted.file.gpg",
   "encrypted_integrity": [
       { "algorithm": "md5", "value": "abcdefghijklmnopqrstuvwxyz"},
       { "algorithm": "sha256", "value": "12345678901234567890"}
   ]
}
```
actual implementation:
```
{
   "user":"john",
   "filepath":"somedir/encrypted.file.gpg",
   "encrypted_checksums": [
       { "type": "md5", "value": "abcdefghijklmnopqrstuvwxyz"},
       { "type": "sha256", "value": "12345678901234567890"}
   ]
}
```


### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->
Needed

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
