### PR TITLE
Test to verify db change for no file disabled because of multiple uploads

### DIFF
--- a/tests/_common/helpers.bash
+++ b/tests/_common/helpers.bash
@@ -36,6 +36,7 @@ MQ_GET="python ${HERE}/mq/get.py --connection ${CEGA_CONNECTION}"
 MQ_GET_INBOX="python ${HERE}/mq/get.py --connection ${CEGA_CONNECTION} v1.files.inbox"
 MQ_GET_COMPLETED="python ${HERE}/mq/get.py --connection ${CEGA_CONNECTION} v1.files.completed"
 MQ_PUBLISH="python ${HERE}/mq/publish.py --connection ${CEGA_CONNECTION}"
+MQ_PURGE="python ${HERE}/mq/purge.py --connection ${CEGA_CONNECTION}"
 
 # Convenience function to capture _all_ outputs
 function legarun {
@@ -258,4 +259,19 @@ function lega_ingest {
     [ "$status" -eq 0 ]
 
     lega_trigger_ingestion "${TESTUSER}" "${TESTFILE_UPLOADED}" $queue 30 10
+}
+
+function query_db {
+    local table=$1
+    local what=$2
+    local where=$3
+
+    if [ "x$what" = x ]; then
+	    what='*'
+    fi 
+    if [ "x$where" != x ]; then
+	  whereclause="where $where"
+    fi
+
+    PGPASSWORD=${DBPASSWORD} psql -tA -h localhost -p 5432 -U lega_in lega -c "select $what from $table $whereclause;"
 }


### PR DESCRIPTION
Verify that the same user can upload a file with the same as has been
previously used by the same user without either file becoming DISABLED.

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->

Tests to verify neicnordic/LocalEGA-db#11.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->

1. Test that verifies that repeated uploads of files with the same name by the same user does not lead does not lead to previous files being put in state `DISABLED`.

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num>" to notify Github that this PR fixes an issue. -->

Requires neicnordic/LocalEGA-db#11 merged and tagged to not provide failed tests.
Provides regression tests for neicnordic/LocalEGA#24.

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

Should be merged after neicnordic/LocalEGA-db#11.
